### PR TITLE
Add inactivity lock overlay with wrapper

### DIFF
--- a/templates/index.templ
+++ b/templates/index.templ
@@ -1,42 +1,44 @@
 package templates
 
 templ Index() {
-	@Layout("Peppo!") {
-		@RecordActionForm("", "#actions-list")
-		<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
-			<!-- Add Person Form (smaller, moved down) -->
-			<div class="bg-white rounded-lg shadow p-4">
-				<h3 class="text-lg font-semibold mb-3">Add New Person</h3>
-				<form hx-post="/api/v1/people" hx-target="#persons-list" hx-swap="afterbegin" class="space-y-3">
-					<input
-						type="text"
-						name="name"
-						placeholder="Person's name"
-						required
-						class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-					/>
-					<button
-						type="submit"
-						class="w-full px-3 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
-					>
-						Add Person
-					</button>
-				</form>
-			</div>
-			<!-- People List -->
-			<div class="bg-white rounded-lg shadow p-4">
-				<h3 class="text-lg font-semibold mb-3">People</h3>
-				<div id="persons-list" hx-get="/api/v1/people" hx-trigger="load">
-					<p class="text-gray-500">Loading...</p>
-				</div>
-			</div>
-			<!-- Actions List -->
-			<div class="bg-white rounded-lg shadow p-4">
-				<h3 class="text-lg font-semibold mb-3">Recent Actions</h3>
-				<div id="actions-list" hx-get="/api/v1/actions" hx-trigger="load">
-					<p class="text-gray-500">Loading...</p>
-				</div>
-			</div>
-		</div>
-	}
+        @Layout("Peppo!") {
+                @LockWrapper() {
+                        @RecordActionForm("", "#actions-list")
+                        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+                                <!-- Add Person Form (smaller, moved down) -->
+                                <div class="bg-white rounded-lg shadow p-4">
+                                        <h3 class="text-lg font-semibold mb-3">Add New Person</h3>
+                                        <form hx-post="/api/v1/people" hx-target="#persons-list" hx-swap="afterbegin" class="space-y-3">
+                                                <input
+                                                        type="text"
+                                                        name="name"
+                                                        placeholder="Person's name"
+                                                        required
+                                                        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                                />
+                                                <button
+                                                        type="submit"
+                                                        class="w-full px-3 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                                >
+                                                        Add Person
+                                                </button>
+                                        </form>
+                                </div>
+                                <!-- People List -->
+                                <div class="bg-white rounded-lg shadow p-4">
+                                        <h3 class="text-lg font-semibold mb-3">People</h3>
+                                        <div id="persons-list" hx-get="/api/v1/people" hx-trigger="load">
+                                                <p class="text-gray-500">Loading...</p>
+                                        </div>
+                                </div>
+                                <!-- Actions List -->
+                                <div class="bg-white rounded-lg shadow p-4">
+                                        <h3 class="text-lg font-semibold mb-3">Recent Actions</h3>
+                                        <div id="actions-list" hx-get="/api/v1/actions" hx-trigger="load">
+                                                <p class="text-gray-500">Loading...</p>
+                                        </div>
+                                </div>
+                        </div>
+                }
+        }
 }

--- a/templates/lock_wrapper.templ
+++ b/templates/lock_wrapper.templ
@@ -1,0 +1,40 @@
+package templates
+
+templ LockWrapper() {
+    <div>
+        { children... }
+        <div id="lock-overlay" class="hidden fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50">
+            <div class="text-white text-2xl">Press r to resume</div>
+        </div>
+        <script>
+                (function() {
+                        const overlay = document.getElementById('lock-overlay');
+                        let timer;
+                        function startTimer() {
+                                timer = setTimeout(() => {
+                                        overlay.classList.remove('hidden');
+                                }, 60000);
+                        }
+                        function resetTimer() {
+                                clearTimeout(timer);
+                                overlay.classList.add('hidden');
+                                startTimer();
+                        }
+                        ['mousemove','keydown','mousedown','touchstart'].forEach(event => {
+                                document.addEventListener(event, () => {
+                                        if (overlay.classList.contains('hidden')) {
+                                                resetTimer();
+                                        }
+                                });
+                        });
+                        document.addEventListener('keydown', (e) => {
+                                if (!overlay.classList.contains('hidden') && e.key === 'r') {
+                                        resetTimer();
+                                }
+                        });
+                        startTimer();
+                })();
+        </script>
+    </div>
+}
+

--- a/templates/person.templ
+++ b/templates/person.templ
@@ -122,78 +122,80 @@ templ PersonSelectLoading() {
 
 templ PersonDetail(person Person, actions []Action) {
 	@Layout(person.Name + " - Person Details") {
-		<!-- Header with back button -->
-		<div class="mb-6">
-			<a href="/" class="text-blue-600 hover:text-blue-800 flex items-center mb-4">
-				← Back to People List
-			</a>
-			<div class="bg-white rounded-lg shadow p-6">
-				<h1 class="text-2xl font-bold text-gray-900 mb-2">{ person.Name }</h1>
-			</div>
-		</div>
-		<!-- Record Action Form -->
-		@RecordActionForm(person.ID, "#actions-list")
-		<!-- Actions section -->
-		<div class="bg-white rounded-lg shadow p-6">
-			<div class="flex justify-between items-center mb-4">
-				<h2 class="text-xl font-semibold text-gray-900">Actions ({ len(actions) })</h2>
-				<a href="/" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded text-sm">
-					Back to Home
+		        @LockWrapper() {
+			<!-- Header with back button -->
+			<div class="mb-6">
+				<a href="/" class="text-blue-600 hover:text-blue-800 flex items-center mb-4">
+					← Back to People List
 				</a>
+				<div class="bg-white rounded-lg shadow p-6">
+					<h1 class="text-2xl font-bold text-gray-900 mb-2">{ person.Name }</h1>
+				</div>
 			</div>
-			<div id="actions-list" class="space-y-4">
-				if len(actions) == 0 {
-					<div class="text-gray-500 text-center py-8" id="no-actions-message">
-						<p class="mb-2">No actions recorded for { person.Name } yet.</p>
-						<p class="text-sm">Use the form above to add the first action!</p>
-					</div>
-				} else {
-					for _, action := range actions {
-						<div class="border-b pb-4 last:border-b-0">
-							<div class="flex items-start justify-between">
-								<div class="flex-1">
-									<div class="flex items-center gap-2 mb-2">
-										<span class={ "inline-block w-3 h-3 rounded-full " + getBgColorForValence(action.Valence) }></span>
-										<span class={ "font-medium capitalize " + getValenceColor(action.Valence) }>{ action.Valence }</span>
-										<span class="text-sm text-gray-500">{ action.OccurredAt.Format("January 2, 2006 at 3:04 PM") }</span>
-									</div>
-									<p class="text-gray-800 mb-2">{ action.Description }</p>
-									if action.References != "" {
-										<div class="text-sm text-blue-600 mb-2">
-											<a href={ templ.URL(action.References) } target="_blank" class="underline hover:no-underline">
-												View Reference →
-											</a>
+			<!-- Record Action Form -->
+			@RecordActionForm(person.ID, "#actions-list")
+			<!-- Actions section -->
+			<div class="bg-white rounded-lg shadow p-6">
+				<div class="flex justify-between items-center mb-4">
+					<h2 class="text-xl font-semibold text-gray-900">Actions ({ len(actions) })</h2>
+					<a href="/" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded text-sm">
+						Back to Home
+					</a>
+				</div>
+				<div id="actions-list" class="space-y-4">
+					if len(actions) == 0 {
+						<div class="text-gray-500 text-center py-8" id="no-actions-message">
+							<p class="mb-2">No actions recorded for { person.Name } yet.</p>
+							<p class="text-sm">Use the form above to add the first action!</p>
+						</div>
+					} else {
+						for _, action := range actions {
+							<div class="border-b pb-4 last:border-b-0">
+								<div class="flex items-start justify-between">
+									<div class="flex-1">
+										<div class="flex items-center gap-2 mb-2">
+											<span class={ "inline-block w-3 h-3 rounded-full " + getBgColorForValence(action.Valence) }></span>
+											<span class={ "font-medium capitalize " + getValenceColor(action.Valence) }>{ action.Valence }</span>
+											<span class="text-sm text-gray-500">{ action.OccurredAt.Format("January 2, 2006 at 3:04 PM") }</span>
 										</div>
-									}
-								</div>
-								<div class="ml-4">
-									<button
-										hx-delete={ "/api/v1/actions/" + action.ID }
-										hx-target="closest .border-b"
-										hx-swap="outerHTML"
-										hx-confirm="Are you sure you want to delete this action?"
-										class="text-red-500 hover:text-red-700 text-sm px-2 py-1 rounded hover:bg-red-50"
-									>
-										Delete
-									</button>
+										<p class="text-gray-800 mb-2">{ action.Description }</p>
+										if action.References != "" {
+											<div class="text-sm text-blue-600 mb-2">
+												<a href={ templ.URL(action.References) } target="_blank" class="underline hover:no-underline">
+													View Reference →
+												</a>
+											</div>
+										}
+									</div>
+									<div class="ml-4">
+										<button
+											hx-delete={ "/api/v1/actions/" + action.ID }
+											hx-target="closest .border-b"
+											hx-swap="outerHTML"
+											hx-confirm="Are you sure you want to delete this action?"
+											class="text-red-500 hover:text-red-700 text-sm px-2 py-1 rounded hover:bg-red-50"
+										>
+											Delete
+										</button>
+									</div>
 								</div>
 							</div>
-						</div>
+						}
 					}
-				}
+				</div>
 			</div>
-		</div>
-		<!-- JavaScript to handle form interactions -->
-		<script>
-			document.addEventListener('htmx:afterRequest', function(event) {
-				// If an action was successfully added, remove the "no actions" message
-				if (event.detail.successful && event.target.closest('form') && event.target.closest('form').action.includes('/actions')) {
-					const noActionsMsg = document.getElementById('no-actions-message');
-					if (noActionsMsg) {
-						noActionsMsg.remove();
+			<!-- JavaScript to handle form interactions -->
+			<script>
+				document.addEventListener('htmx:afterRequest', function(event) {
+					// If an action was successfully added, remove the "no actions" message
+					if (event.detail.successful && event.target.closest('form') && event.target.closest('form').action.includes('/actions')) {
+						const noActionsMsg = document.getElementById('no-actions-message');
+						if (noActionsMsg) {
+							noActionsMsg.remove();
+						}
 					}
-				}
-			});
-		</script>
+				});
+			</script>
+                }
 	}
 }


### PR DESCRIPTION
## Summary
- introduce `LockWrapper` component adding 60s inactivity overlay requiring `r` to resume
- wrap index and person detail pages with the new component

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: package pepo/internal/api is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_68a60ca6a810832c905defcad2393b16