### PR TITLE
Add GitHub Action for Go tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Go Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Check formatting
+        run: go fmt ./... && git diff --exit-code
+
+      - name: Run tests
+        run: go test ./...


### PR DESCRIPTION
## Summary
- run `go fmt` and tests in CI

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: package pepo/internal/api is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_68a6043c1b08832c99efbea7d2b6f820