### PR TITLE
Ensure inactivity overlay fully obscures page

### DIFF
--- a/templates/lock_wrapper.templ
+++ b/templates/lock_wrapper.templ
@@ -3,7 +3,7 @@ package templates
 templ LockWrapper() {
     <div>
         { children... }
-        <div id="lock-overlay" class="hidden fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50">
+        <div id="lock-overlay" class="hidden fixed inset-0 flex items-center justify-center bg-gray-900 z-[1000]">
             <div class="text-white text-2xl">Press r to resume</div>
         </div>
         <script>


### PR DESCRIPTION
## Summary
- Make inactivity overlay fully opaque and raise its z-index to stay above all page content

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: package pepo/internal/api is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_68a6200b77c4832c872e4e9b4c7b097f