### PR TITLE
Add Fly.io deployment configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM golang:1.23 AS builder
+WORKDIR /app
+
+# Download dependencies first to leverage Docker layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the server binary
+RUN CGO_ENABLED=0 GOOS=linux go build -o /pepo-server ./cmd/server
+
+# Run stage
+FROM gcr.io/distroless/base-debian12
+
+# Set working directory and copy binary
+WORKDIR /
+COPY --from=builder /pepo-server /pepo-server
+
+# Expose service port and run
+EXPOSE 8080
+ENV PORT=8080
+CMD ["/pepo-server"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,21 @@
+app = "pepo"
+
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 8080
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile that builds the server from `cmd/server`
- introduce `fly.toml` for Fly.io deployment with HTTP service on port 8080

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a64527ffa8832ca2bf11bc680a2df9