### PR TITLE
docs: add migration naming guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,4 @@ This repository contains a Go-based web application for tracking performance of 
 - Run tests with `go test ./...` (or `make test`) to ensure all tests pass.
 - Table names are singular, eg action, person.
 - API routes are plural, eg GET /actions, GET /people
+- Name migrations using the current timestamp, e.g. `20240115093000_add_user_table.sql`.


### PR DESCRIPTION
## Summary
- document naming migrations with current timestamp

## Testing
- `go fmt ./...`
- `make test` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a665ab7370832caec83f41c1d87a83