### PR TITLE
Use named SQL parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,4 @@ This repository contains a Go-based web application for tracking performance of 
 - Table names are singular, eg action, person.
 - API routes are plural, eg GET /actions, GET /people
 - Name migrations using the current timestamp, e.g. `20240115093000_add_user_table.sql`.
+- Use named SQL parameters (e.g., `sqlc.arg(name)`) instead of positional placeholders like `$1`.

--- a/cmd/mcpserver/main.go
+++ b/cmd/mcpserver/main.go
@@ -68,9 +68,9 @@ func main() {
 		}
 
 		rows, err := queries.ListActionsByPersonID(ctx, db.ListActionsByPersonIDParams{
-			XidStr: args.PersonID,
-			Limit:  int32(limit),
-			Offset: int32(offset),
+			PersonID: args.PersonID,
+			Offset:   int32(offset),
+			Limit:    int32(limit),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list actions: %w", err)

--- a/db/queries/action_themes.sql
+++ b/db/queries/action_themes.sql
@@ -1,23 +1,23 @@
 -- name: AddThemeToAction :exec
 INSERT INTO action_theme (action_id, theme_id)
-VALUES (x2b($1), x2b($2));
+VALUES (x2b(sqlc.arg(action_id)), x2b(sqlc.arg(theme_id)));
 
 -- name: RemoveThemeFromAction :exec
 DELETE FROM action_theme
-WHERE action_id = x2b($1) AND theme_id = x2b($2);
+WHERE action_id = x2b(sqlc.arg(action_id)) AND theme_id = x2b(sqlc.arg(theme_id));
 
 -- name: ListThemesByActionID :many
 SELECT sqlc.embed(theme)
 FROM action_theme at
 JOIN theme ON at.theme_id = theme.id
-WHERE at.action_id = x2b($1)
+WHERE at.action_id = x2b(sqlc.arg(action_id))
 ORDER BY theme.created_at DESC
-LIMIT $2 OFFSET $3;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: ListActionsByThemeID :many
 SELECT sqlc.embed(action)
 FROM action_theme at
 JOIN action ON at.action_id = action.id
-WHERE at.theme_id = x2b($1)
+WHERE at.theme_id = x2b(sqlc.arg(theme_id))
 ORDER BY action.created_at DESC
-LIMIT $2 OFFSET $3;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');

--- a/db/queries/actions.sql
+++ b/db/queries/actions.sql
@@ -1,63 +1,75 @@
 -- name: CreateAction :one
 INSERT INTO action (id, person_id, occurred_at, description, "references", valence)
-VALUES (x2b($1), x2b($2), $3, $4, $5, $6)
+VALUES (
+    x2b(sqlc.arg(id)),
+    x2b(sqlc.arg(person_id)),
+    sqlc.arg(occurred_at),
+    sqlc.arg(description),
+    sqlc.arg('references'),
+    sqlc.arg(valence)
+)
 RETURNING sqlc.embed(action);
 
 -- name: GetActionByID :one
 SELECT sqlc.embed(action)
 FROM action
-WHERE id = x2b($1);
+WHERE id = x2b(sqlc.arg(id));
 
 -- name: ListActions :many
 SELECT sqlc.embed(action), person.name as person_name
 FROM action
 JOIN person ON action.person_id = person.id
 ORDER BY occurred_at DESC
-LIMIT $1 OFFSET $2;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: ListActionsByPersonID :many
 SELECT sqlc.embed(action)
 FROM action
-WHERE person_id = x2b($1)
+WHERE person_id = x2b(sqlc.arg(person_id))
 ORDER BY occurred_at DESC
-LIMIT $2 OFFSET $3;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: CountActions :one
 SELECT COUNT(*) FROM action;
 
 -- name: CountActionsByPersonID :one
-SELECT COUNT(*) FROM action WHERE person_id = x2b($1);
+SELECT COUNT(*) FROM action WHERE person_id = x2b(sqlc.arg(person_id));
 
 -- name: UpdateAction :one
 UPDATE action
-SET person_id = x2b($2), occurred_at = $3, description = $4, "references" = $5, valence = $6, updated_at = NOW()
-WHERE id = x2b($1)
+SET person_id = x2b(sqlc.arg(person_id)),
+    occurred_at = sqlc.arg(occurred_at),
+    description = sqlc.arg(description),
+    "references" = sqlc.arg('references'),
+    valence = sqlc.arg(valence),
+    updated_at = NOW()
+WHERE id = x2b(sqlc.arg(id))
 RETURNING sqlc.embed(action);
 
 -- name: DeleteAction :exec
 DELETE FROM action
-WHERE id = x2b($1);
+WHERE id = x2b(sqlc.arg(id));
 
 -- name: ListActionsByValence :many
 SELECT sqlc.embed(action)
 FROM action
-WHERE valence = $1
+WHERE valence = sqlc.arg(valence)
 ORDER BY occurred_at DESC
-LIMIT $2 OFFSET $3;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: ListActionsByPersonIDAndValence :many
 SELECT sqlc.embed(action)
 FROM action
-WHERE person_id = x2b($1) AND valence = $2
+WHERE person_id = x2b(sqlc.arg(person_id)) AND valence = sqlc.arg(valence)
 ORDER BY occurred_at DESC
-LIMIT $3 OFFSET $4;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: SearchActionsByDescription :many
 SELECT sqlc.embed(action)
 FROM action
-WHERE description ILIKE '%' || $1 || '%'
+WHERE description ILIKE '%' || sqlc.arg('search') || '%'
 ORDER BY occurred_at DESC
-LIMIT $2 OFFSET $3;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: GetActionsWithPersonDetails :many
 SELECT
@@ -73,18 +85,18 @@ SELECT
 FROM action a
 JOIN person p ON a.person_id = p.id
 ORDER BY a.occurred_at DESC
-LIMIT $1 OFFSET $2;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: GetActionsByDateRange :many
 SELECT sqlc.embed(action)
 FROM action
-WHERE occurred_at >= $1 AND occurred_at <= $2
+WHERE occurred_at >= sqlc.arg(start_time) AND occurred_at <= sqlc.arg(end_time)
 ORDER BY occurred_at DESC
-LIMIT $3 OFFSET $4;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: GetRecentActionsByPersonID :many
 SELECT sqlc.embed(action)
 FROM action
-WHERE person_id = x2b($1) AND occurred_at >= $2
+WHERE person_id = x2b(sqlc.arg(person_id)) AND occurred_at >= sqlc.arg(since)
 ORDER BY occurred_at DESC
-LIMIT $3 OFFSET $4;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');

--- a/db/queries/persons.sql
+++ b/db/queries/persons.sql
@@ -1,43 +1,43 @@
 -- name: CreatePerson :one
 INSERT INTO person (id, name)
-VALUES (x2b($1), $2)
+VALUES (x2b(sqlc.arg(id)), sqlc.arg(name))
 RETURNING b2x(id) as id, name, created_at, updated_at;
 
 -- name: GetPersonByID :one
 SELECT b2x(id) as id, name, created_at, updated_at
 FROM person
-WHERE id = x2b($1);
+WHERE id = x2b(sqlc.arg(id));
 
 -- name: ListPersons :many
 SELECT b2x(id) as id, name, created_at, updated_at
 FROM person
 ORDER BY created_at DESC
-LIMIT $1 OFFSET $2;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: CountPersons :one
 SELECT COUNT(*) FROM person;
 
 -- name: UpdatePerson :one
 UPDATE person
-SET name = $2, updated_at = NOW()
-WHERE id = x2b($1)
+SET name = sqlc.arg(name), updated_at = NOW()
+WHERE id = x2b(sqlc.arg(id))
 RETURNING b2x(id) as id, name, created_at, updated_at;
 
 -- name: DeletePerson :exec
 DELETE FROM person
-WHERE id = x2b($1);
+WHERE id = x2b(sqlc.arg(id));
 
 -- name: GetPersonByName :one
 SELECT b2x(id) as id, name, created_at, updated_at
 FROM person
-WHERE name = $1;
+WHERE name = sqlc.arg(name);
 
 -- name: SearchPersonsByName :many
 SELECT b2x(id) as id, name, created_at, updated_at
 FROM person
-WHERE name ILIKE '%' || $1 || '%'
+WHERE name ILIKE '%' || sqlc.arg('search') || '%'
 ORDER BY name
-LIMIT $2 OFFSET $3;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: ListPersonsWithLastAction :many
 SELECT
@@ -50,4 +50,4 @@ FROM person p
 LEFT JOIN action a ON p.id = a.person_id
 GROUP BY p.id, p.name, p.created_at, p.updated_at
 ORDER BY p.created_at DESC
-LIMIT $1 OFFSET $2;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');

--- a/db/queries/themes.sql
+++ b/db/queries/themes.sql
@@ -1,26 +1,26 @@
 -- name: CreateTheme :one
 INSERT INTO theme (id, person_id, text)
-VALUES (x2b($1), x2b($2), $3)
+VALUES (x2b(sqlc.arg(id)), x2b(sqlc.arg(person_id)), sqlc.arg(text))
 RETURNING sqlc.embed(theme);
 
 -- name: GetThemeByID :one
 SELECT sqlc.embed(theme)
 FROM theme
-WHERE id = x2b($1);
+WHERE id = x2b(sqlc.arg(id));
 
 -- name: ListThemes :many
 SELECT sqlc.embed(theme)
 FROM theme
 ORDER BY created_at DESC
-LIMIT $1 OFFSET $2;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: ListThemesByPersonID :many
 SELECT sqlc.embed(theme)
 FROM theme
-WHERE person_id = x2b($1)
+WHERE person_id = x2b(sqlc.arg(person_id))
 ORDER BY created_at DESC
-LIMIT $2 OFFSET $3;
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: DeleteTheme :exec
 DELETE FROM theme
-WHERE id = x2b($1);
+WHERE id = x2b(sqlc.arg(id));

--- a/internal/db/action_themes.sql.go
+++ b/internal/db/action_themes.sql.go
@@ -15,12 +15,12 @@ VALUES (x2b($1), x2b($2))
 `
 
 type AddThemeToActionParams struct {
-	XidStr   string `db:"xid_str" json:"xid_str"`
-	XidStr_2 string `db:"xid_str_2" json:"xid_str_2"`
+	ActionID string `db:"action_id" json:"action_id"`
+	ThemeID  string `db:"theme_id" json:"theme_id"`
 }
 
 func (q *Queries) AddThemeToAction(ctx context.Context, arg AddThemeToActionParams) error {
-	_, err := q.db.ExecContext(ctx, addThemeToAction, arg.XidStr, arg.XidStr_2)
+	_, err := q.db.ExecContext(ctx, addThemeToAction, arg.ActionID, arg.ThemeID)
 	return err
 }
 
@@ -30,13 +30,13 @@ FROM action_theme at
 JOIN action ON at.action_id = action.id
 WHERE at.theme_id = x2b($1)
 ORDER BY action.created_at DESC
-LIMIT $2 OFFSET $3
+LIMIT $3 OFFSET $2
 `
 
 type ListActionsByThemeIDParams struct {
-	XidStr string `db:"xid_str" json:"xid_str"`
-	Limit  int32  `db:"limit" json:"limit"`
-	Offset int32  `db:"offset" json:"offset"`
+	ThemeID string `db:"theme_id" json:"theme_id"`
+	Offset  int32  `db:"offset" json:"offset"`
+	Limit   int32  `db:"limit" json:"limit"`
 }
 
 type ListActionsByThemeIDRow struct {
@@ -44,7 +44,7 @@ type ListActionsByThemeIDRow struct {
 }
 
 func (q *Queries) ListActionsByThemeID(ctx context.Context, arg ListActionsByThemeIDParams) ([]ListActionsByThemeIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, listActionsByThemeID, arg.XidStr, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, listActionsByThemeID, arg.ThemeID, arg.Offset, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
@@ -81,13 +81,13 @@ FROM action_theme at
 JOIN theme ON at.theme_id = theme.id
 WHERE at.action_id = x2b($1)
 ORDER BY theme.created_at DESC
-LIMIT $2 OFFSET $3
+LIMIT $3 OFFSET $2
 `
 
 type ListThemesByActionIDParams struct {
-	XidStr string `db:"xid_str" json:"xid_str"`
-	Limit  int32  `db:"limit" json:"limit"`
-	Offset int32  `db:"offset" json:"offset"`
+	ActionID string `db:"action_id" json:"action_id"`
+	Offset   int32  `db:"offset" json:"offset"`
+	Limit    int32  `db:"limit" json:"limit"`
 }
 
 type ListThemesByActionIDRow struct {
@@ -95,7 +95,7 @@ type ListThemesByActionIDRow struct {
 }
 
 func (q *Queries) ListThemesByActionID(ctx context.Context, arg ListThemesByActionIDParams) ([]ListThemesByActionIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, listThemesByActionID, arg.XidStr, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, listThemesByActionID, arg.ActionID, arg.Offset, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
@@ -129,11 +129,11 @@ WHERE action_id = x2b($1) AND theme_id = x2b($2)
 `
 
 type RemoveThemeFromActionParams struct {
-	XidStr   string `db:"xid_str" json:"xid_str"`
-	XidStr_2 string `db:"xid_str_2" json:"xid_str_2"`
+	ActionID string `db:"action_id" json:"action_id"`
+	ThemeID  string `db:"theme_id" json:"theme_id"`
 }
 
 func (q *Queries) RemoveThemeFromAction(ctx context.Context, arg RemoveThemeFromActionParams) error {
-	_, err := q.db.ExecContext(ctx, removeThemeFromAction, arg.XidStr, arg.XidStr_2)
+	_, err := q.db.ExecContext(ctx, removeThemeFromAction, arg.ActionID, arg.ThemeID)
 	return err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -82,11 +82,33 @@ type Action struct {
 	UpdatedAt   time.Time      `db:"updated_at" json:"updated_at"`
 }
 
+type ActionConversation struct {
+	ActionID       []byte    `db:"action_id" json:"action_id"`
+	ConversationID []byte    `db:"conversation_id" json:"conversation_id"`
+	CreatedAt      time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt      time.Time `db:"updated_at" json:"updated_at"`
+}
+
 type ActionTheme struct {
 	ActionID  []byte    `db:"action_id" json:"action_id"`
 	ThemeID   []byte    `db:"theme_id" json:"theme_id"`
 	CreatedAt time.Time `db:"created_at" json:"created_at"`
 	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
+}
+
+type Conversation struct {
+	ID          []byte    `db:"id" json:"id"`
+	Description string    `db:"description" json:"description"`
+	OccurredAt  time.Time `db:"occurred_at" json:"occurred_at"`
+	CreatedAt   time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt   time.Time `db:"updated_at" json:"updated_at"`
+}
+
+type ConversationTheme struct {
+	ConversationID []byte    `db:"conversation_id" json:"conversation_id"`
+	ThemeID        []byte    `db:"theme_id" json:"theme_id"`
+	CreatedAt      time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt      time.Time `db:"updated_at" json:"updated_at"`
 }
 
 type Person struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -11,21 +11,21 @@ import (
 type Querier interface {
 	AddThemeToAction(ctx context.Context, arg AddThemeToActionParams) error
 	CountActions(ctx context.Context) (int64, error)
-	CountActionsByPersonID(ctx context.Context, xidStr string) (int64, error)
+	CountActionsByPersonID(ctx context.Context, personID string) (int64, error)
 	CountPersons(ctx context.Context) (int64, error)
 	CreateAction(ctx context.Context, arg CreateActionParams) (CreateActionRow, error)
 	CreatePerson(ctx context.Context, arg CreatePersonParams) (CreatePersonRow, error)
 	CreateTheme(ctx context.Context, arg CreateThemeParams) (CreateThemeRow, error)
-	DeleteAction(ctx context.Context, xidStr string) error
-	DeletePerson(ctx context.Context, xidStr string) error
-	DeleteTheme(ctx context.Context, xidStr string) error
-	GetActionByID(ctx context.Context, xidStr string) (GetActionByIDRow, error)
+	DeleteAction(ctx context.Context, id string) error
+	DeletePerson(ctx context.Context, id string) error
+	DeleteTheme(ctx context.Context, id string) error
+	GetActionByID(ctx context.Context, id string) (GetActionByIDRow, error)
 	GetActionsByDateRange(ctx context.Context, arg GetActionsByDateRangeParams) ([]GetActionsByDateRangeRow, error)
 	GetActionsWithPersonDetails(ctx context.Context, arg GetActionsWithPersonDetailsParams) ([]GetActionsWithPersonDetailsRow, error)
-	GetPersonByID(ctx context.Context, xidStr string) (GetPersonByIDRow, error)
+	GetPersonByID(ctx context.Context, id string) (GetPersonByIDRow, error)
 	GetPersonByName(ctx context.Context, name string) (GetPersonByNameRow, error)
 	GetRecentActionsByPersonID(ctx context.Context, arg GetRecentActionsByPersonIDParams) ([]GetRecentActionsByPersonIDRow, error)
-	GetThemeByID(ctx context.Context, xidStr string) (GetThemeByIDRow, error)
+	GetThemeByID(ctx context.Context, id string) (GetThemeByIDRow, error)
 	ListActions(ctx context.Context, arg ListActionsParams) ([]ListActionsRow, error)
 	ListActionsByPersonID(ctx context.Context, arg ListActionsByPersonIDParams) ([]ListActionsByPersonIDRow, error)
 	ListActionsByPersonIDAndValence(ctx context.Context, arg ListActionsByPersonIDAndValenceParams) ([]ListActionsByPersonIDAndValenceRow, error)

--- a/internal/db/themes.sql.go
+++ b/internal/db/themes.sql.go
@@ -16,8 +16,8 @@ RETURNING theme.id, theme.person_id, theme.text, theme.created_at, theme.updated
 `
 
 type CreateThemeParams struct {
-	XidStr   string `db:"xid_str" json:"xid_str"`
-	XidStr_2 string `db:"xid_str_2" json:"xid_str_2"`
+	ID       string `db:"id" json:"id"`
+	PersonID string `db:"person_id" json:"person_id"`
 	Text     string `db:"text" json:"text"`
 }
 
@@ -26,7 +26,7 @@ type CreateThemeRow struct {
 }
 
 func (q *Queries) CreateTheme(ctx context.Context, arg CreateThemeParams) (CreateThemeRow, error) {
-	row := q.db.QueryRowContext(ctx, createTheme, arg.XidStr, arg.XidStr_2, arg.Text)
+	row := q.db.QueryRowContext(ctx, createTheme, arg.ID, arg.PersonID, arg.Text)
 	var i CreateThemeRow
 	err := row.Scan(
 		&i.Theme.ID,
@@ -43,8 +43,8 @@ DELETE FROM theme
 WHERE id = x2b($1)
 `
 
-func (q *Queries) DeleteTheme(ctx context.Context, xidStr string) error {
-	_, err := q.db.ExecContext(ctx, deleteTheme, xidStr)
+func (q *Queries) DeleteTheme(ctx context.Context, id string) error {
+	_, err := q.db.ExecContext(ctx, deleteTheme, id)
 	return err
 }
 
@@ -58,8 +58,8 @@ type GetThemeByIDRow struct {
 	Theme Theme `db:"theme" json:"theme"`
 }
 
-func (q *Queries) GetThemeByID(ctx context.Context, xidStr string) (GetThemeByIDRow, error) {
-	row := q.db.QueryRowContext(ctx, getThemeByID, xidStr)
+func (q *Queries) GetThemeByID(ctx context.Context, id string) (GetThemeByIDRow, error) {
+	row := q.db.QueryRowContext(ctx, getThemeByID, id)
 	var i GetThemeByIDRow
 	err := row.Scan(
 		&i.Theme.ID,
@@ -75,12 +75,12 @@ const listThemes = `-- name: ListThemes :many
 SELECT theme.id, theme.person_id, theme.text, theme.created_at, theme.updated_at
 FROM theme
 ORDER BY created_at DESC
-LIMIT $1 OFFSET $2
+LIMIT $2 OFFSET $1
 `
 
 type ListThemesParams struct {
-	Limit  int32 `db:"limit" json:"limit"`
 	Offset int32 `db:"offset" json:"offset"`
+	Limit  int32 `db:"limit" json:"limit"`
 }
 
 type ListThemesRow struct {
@@ -88,7 +88,7 @@ type ListThemesRow struct {
 }
 
 func (q *Queries) ListThemes(ctx context.Context, arg ListThemesParams) ([]ListThemesRow, error) {
-	rows, err := q.db.QueryContext(ctx, listThemes, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, listThemes, arg.Offset, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
@@ -121,13 +121,13 @@ SELECT theme.id, theme.person_id, theme.text, theme.created_at, theme.updated_at
 FROM theme
 WHERE person_id = x2b($1)
 ORDER BY created_at DESC
-LIMIT $2 OFFSET $3
+LIMIT $3 OFFSET $2
 `
 
 type ListThemesByPersonIDParams struct {
-	XidStr string `db:"xid_str" json:"xid_str"`
-	Limit  int32  `db:"limit" json:"limit"`
-	Offset int32  `db:"offset" json:"offset"`
+	PersonID string `db:"person_id" json:"person_id"`
+	Offset   int32  `db:"offset" json:"offset"`
+	Limit    int32  `db:"limit" json:"limit"`
 }
 
 type ListThemesByPersonIDRow struct {
@@ -135,7 +135,7 @@ type ListThemesByPersonIDRow struct {
 }
 
 func (q *Queries) ListThemesByPersonID(ctx context.Context, arg ListThemesByPersonIDParams) ([]ListThemesByPersonIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, listThemesByPersonID, arg.XidStr, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, listThemesByPersonID, arg.PersonID, arg.Offset, arg.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handlers/person.go
+++ b/internal/handlers/person.go
@@ -40,8 +40,8 @@ func (h *PersonHandler) CreatePerson(ctx context.Context, req *api.CreatePersonR
 
 	// Create person in database
 	person, err := h.queries.CreatePerson(ctx, db.CreatePersonParams{
-		XidStr: personID,
-		Name:   req.Name,
+		ID:   personID,
+		Name: req.Name,
 	})
 	if err != nil {
 		log.Printf("Error creating person: %v", err)
@@ -107,8 +107,8 @@ func (h *PersonHandler) GetPersons(ctx context.Context, params api.GetPersonsPar
 
 	// Get persons
 	persons, err := h.queries.ListPersons(ctx, db.ListPersonsParams{
-		Limit:  limit,
 		Offset: offset,
+		Limit:  limit,
 	})
 	if err != nil {
 		log.Printf("Error listing persons: %v", err)
@@ -196,8 +196,8 @@ func (h *PersonHandler) UpdatePerson(ctx context.Context, req *api.UpdatePersonR
 	}
 
 	person, err := h.queries.UpdatePerson(ctx, db.UpdatePersonParams{
-		XidStr: params.ID,
-		Name:   req.Name,
+		ID:   params.ID,
+		Name: req.Name,
 	})
 	if err != nil {
 		if err == sql.ErrNoRows {


### PR DESCRIPTION
## Summary
- enforce named SQL parameters in repository guidelines
- refactor SQL queries to use `sqlc.arg` named parameters
- update handlers to use new generated parameter structs

## Testing
- `sqlc generate`
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a670400560832c8f08cdc6cee12a9b