### PR TITLE
docs: explain API code generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,13 +3,14 @@
 This repository contains a Go-based web application for tracking performance of direct reports. Key technologies and workflows:
 
 - **Language & Frameworks:** Go for server-side code; frontend leverages HTMX and Tailwind CSS.
-- **API:** RESTful API described with OpenAPI, code generated via [ogen](https://ogen.dev/).
+- **API:** RESTful API described with OpenAPI. The spec lives at `api/openapi.yaml` and code is generated via [ogen](https://ogen.dev/) into `internal/api`. Run `make generate-api` after modifying the spec to refresh the generated code.
 - **Database:** PostgreSQL with interactions generated through [sqlc](https://sqlc.dev/); schema managed by [dbmate](https://github.com/amacneil/dbmate). Primary keys use [xid](https://github.com/rs/xid).
 
 ## Development Guidelines
 
 - Format Go code with `go fmt ./...` before committing.
 - Run tests with `go test ./...` (or `make test`) to ensure all tests pass.
+- After updating `api/openapi.yaml`, run `make generate-api` to regenerate API code.
 - Table names are singular, eg action, person.
 - API routes are plural, eg GET /actions, GET /people
 - Name migrations using the current timestamp, e.g. `20240115093000_add_user_table.sql`.


### PR DESCRIPTION
## Summary
- document API code generation process in AGENTS guide
- note to run `make generate-api` after updating api spec

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a67c7f31a0832caeec5bc5e307e4a9