### PR TITLE
chore(api): add themes to action requests

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -638,6 +638,11 @@ components:
           description: Emotional valence of the action
           enum: ["positive", "negative", "neutral"]
           example: "positive"
+        themes:
+          type: array
+          description: IDs of themes associated with the action
+          items:
+            type: string
       required:
         - person_id
         - occurred_at
@@ -672,6 +677,11 @@ components:
           description: Whether the action was positive or negative
           enum: [positive, negative]
           example: "positive"
+        themes:
+          type: array
+          description: IDs of themes associated with the action
+          items:
+            type: string
       required:
         - person_id
         - occurred_at

--- a/internal/api/oas_json_gen.go
+++ b/internal/api/oas_json_gen.go
@@ -391,14 +391,25 @@ func (s *CreateActionRequest) encodeFields(e *jx.Encoder) {
 		e.FieldStart("valence")
 		s.Valence.Encode(e)
 	}
+	{
+		if s.Themes != nil {
+			e.FieldStart("themes")
+			e.ArrStart()
+			for _, elem := range s.Themes {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfCreateActionRequest = [5]string{
+var jsonFieldsNameOfCreateActionRequest = [6]string{
 	0: "person_id",
 	1: "occurred_at",
 	2: "description",
 	3: "references",
 	4: "valence",
+	5: "themes",
 }
 
 // Decode decodes CreateActionRequest from json.
@@ -465,6 +476,25 @@ func (s *CreateActionRequest) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"valence\"")
+			}
+		case "themes":
+			if err := func() error {
+				s.Themes = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Themes = append(s.Themes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"themes\"")
 			}
 		default:
 			return d.Skip()
@@ -1976,14 +2006,25 @@ func (s *UpdateActionRequest) encodeFields(e *jx.Encoder) {
 		e.FieldStart("valence")
 		s.Valence.Encode(e)
 	}
+	{
+		if s.Themes != nil {
+			e.FieldStart("themes")
+			e.ArrStart()
+			for _, elem := range s.Themes {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfUpdateActionRequest = [5]string{
+var jsonFieldsNameOfUpdateActionRequest = [6]string{
 	0: "person_id",
 	1: "occurred_at",
 	2: "description",
 	3: "references",
 	4: "valence",
+	5: "themes",
 }
 
 // Decode decodes UpdateActionRequest from json.
@@ -2050,6 +2091,25 @@ func (s *UpdateActionRequest) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"valence\"")
+			}
+		case "themes":
+			if err := func() error {
+				s.Themes = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Themes = append(s.Themes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"themes\"")
 			}
 		default:
 			return d.Skip()

--- a/internal/api/oas_schemas_gen.go
+++ b/internal/api/oas_schemas_gen.go
@@ -203,6 +203,8 @@ type CreateActionRequest struct {
 	References OptNilString `json:"references"`
 	// Emotional valence of the action.
 	Valence CreateActionRequestValence `json:"valence"`
+	// IDs of themes associated with the action.
+	Themes []string `json:"themes"`
 }
 
 // GetPersonID returns the value of PersonID.
@@ -230,6 +232,11 @@ func (s *CreateActionRequest) GetValence() CreateActionRequestValence {
 	return s.Valence
 }
 
+// GetThemes returns the value of Themes.
+func (s *CreateActionRequest) GetThemes() []string {
+	return s.Themes
+}
+
 // SetPersonID sets the value of PersonID.
 func (s *CreateActionRequest) SetPersonID(val string) {
 	s.PersonID = val
@@ -253,6 +260,11 @@ func (s *CreateActionRequest) SetReferences(val OptNilString) {
 // SetValence sets the value of Valence.
 func (s *CreateActionRequest) SetValence(val CreateActionRequestValence) {
 	s.Valence = val
+}
+
+// SetThemes sets the value of Themes.
+func (s *CreateActionRequest) SetThemes(val []string) {
+	s.Themes = val
 }
 
 // Emotional valence of the action.
@@ -1014,6 +1026,8 @@ type UpdateActionRequest struct {
 	References OptNilString `json:"references"`
 	// Whether the action was positive or negative.
 	Valence UpdateActionRequestValence `json:"valence"`
+	// IDs of themes associated with the action.
+	Themes []string `json:"themes"`
 }
 
 // GetPersonID returns the value of PersonID.
@@ -1041,6 +1055,11 @@ func (s *UpdateActionRequest) GetValence() UpdateActionRequestValence {
 	return s.Valence
 }
 
+// GetThemes returns the value of Themes.
+func (s *UpdateActionRequest) GetThemes() []string {
+	return s.Themes
+}
+
 // SetPersonID sets the value of PersonID.
 func (s *UpdateActionRequest) SetPersonID(val string) {
 	s.PersonID = val
@@ -1064,6 +1083,11 @@ func (s *UpdateActionRequest) SetReferences(val OptNilString) {
 // SetValence sets the value of Valence.
 func (s *UpdateActionRequest) SetValence(val UpdateActionRequestValence) {
 	s.Valence = val
+}
+
+// SetThemes sets the value of Themes.
+func (s *UpdateActionRequest) SetThemes(val []string) {
+	s.Themes = val
 }
 
 // Whether the action was positive or negative.


### PR DESCRIPTION
## Summary
- allow action creation and update requests to include theme IDs as strings
- regenerate ogen types and use request theme IDs in action handler

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a679d56964832cb4dea14e986f3349