### PR TITLE
feat: add theme creation endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -644,10 +644,6 @@ components:
           items:
             type: string
             pattern: "^[0-9a-v]{20}$"
-        newTheme:
-          type: string
-          description: Name of a new theme to create and associate with the action
-          example: "communication"
       required:
         - person_id
         - occurred_at

--- a/internal/api/oas_json_gen.go
+++ b/internal/api/oas_json_gen.go
@@ -401,22 +401,15 @@ func (s *CreateActionRequest) encodeFields(e *jx.Encoder) {
 			e.ArrEnd()
 		}
 	}
-	{
-		if s.NewTheme.Set {
-			e.FieldStart("newTheme")
-			s.NewTheme.Encode(e)
-		}
-	}
 }
 
-var jsonFieldsNameOfCreateActionRequest = [7]string{
+var jsonFieldsNameOfCreateActionRequest = [6]string{
 	0: "person_id",
 	1: "occurred_at",
 	2: "description",
 	3: "references",
 	4: "valence",
 	5: "themes",
-	6: "newTheme",
 }
 
 // Decode decodes CreateActionRequest from json.
@@ -502,16 +495,6 @@ func (s *CreateActionRequest) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"themes\"")
-			}
-		case "newTheme":
-			if err := func() error {
-				s.NewTheme.Reset()
-				if err := s.NewTheme.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"newTheme\"")
 			}
 		default:
 			return d.Skip()

--- a/internal/api/oas_schemas_gen.go
+++ b/internal/api/oas_schemas_gen.go
@@ -205,8 +205,6 @@ type CreateActionRequest struct {
 	Valence CreateActionRequestValence `json:"valence"`
 	// IDs of themes associated with the action.
 	Themes []string `json:"themes"`
-	// Name of a new theme to create and associate with the action.
-	NewTheme OptString `json:"newTheme"`
 }
 
 // GetPersonID returns the value of PersonID.
@@ -239,11 +237,6 @@ func (s *CreateActionRequest) GetThemes() []string {
 	return s.Themes
 }
 
-// GetNewTheme returns the value of NewTheme.
-func (s *CreateActionRequest) GetNewTheme() OptString {
-	return s.NewTheme
-}
-
 // SetPersonID sets the value of PersonID.
 func (s *CreateActionRequest) SetPersonID(val string) {
 	s.PersonID = val
@@ -272,11 +265,6 @@ func (s *CreateActionRequest) SetValence(val CreateActionRequestValence) {
 // SetThemes sets the value of Themes.
 func (s *CreateActionRequest) SetThemes(val []string) {
 	s.Themes = val
-}
-
-// SetNewTheme sets the value of NewTheme.
-func (s *CreateActionRequest) SetNewTheme(val OptString) {
-	s.NewTheme = val
 }
 
 // Emotional valence of the action.

--- a/internal/handlers/action.go
+++ b/internal/handlers/action.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"net/http"
+	"strings"
 
 	"github.com/rs/xid"
 
@@ -90,32 +91,6 @@ func (h *ActionHandler) CreateAction(ctx context.Context, req *api.CreateActionR
 			ThemeID:  tID,
 		}); err != nil {
 			zap.L().Error("error adding theme to action", zap.Error(err))
-			return &api.CreateActionInternalServerError{
-				Message: "Failed to associate theme",
-				Code:    "INTERNAL_ERROR",
-			}, nil
-		}
-	}
-
-	// Create a new theme if provided
-	if req.NewTheme.IsSet() {
-		themeID := xid.New().String()
-		if _, err := h.queries.CreateTheme(ctx, db.CreateThemeParams{
-			ID:       themeID,
-			PersonID: req.PersonID,
-			Text:     req.NewTheme.Value,
-		}); err != nil {
-			zap.L().Error("error creating theme", zap.Error(err))
-			return &api.CreateActionInternalServerError{
-				Message: "Failed to create theme",
-				Code:    "INTERNAL_ERROR",
-			}, nil
-		}
-		if err := h.queries.AddThemeToAction(ctx, db.AddThemeToActionParams{
-			ActionID: actionID,
-			ThemeID:  themeID,
-		}); err != nil {
-			zap.L().Error("error adding new theme to action", zap.Error(err))
 			return &api.CreateActionInternalServerError{
 				Message: "Failed to associate theme",
 				Code:    "INTERNAL_ERROR",
@@ -472,6 +447,65 @@ func (h *ActionHandler) HandleGetThemesForSelect(w http.ResponseWriter, r *http.
 		Limit:    100,
 	})
 	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		templates.ThemeSelectError().Render(r.Context(), w)
+		return
+	}
+
+	themes := make([]templates.Theme, len(rows))
+	for i, row := range rows {
+		t := row.Theme
+		themes[i] = templates.Theme{
+			ID:       t.ID.String(),
+			Text:     t.Text,
+			Selected: selected[t.ID.String()],
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	templates.ThemeSelectOptions(themes).Render(r.Context(), w)
+}
+
+func (h *ActionHandler) HandleCreateTheme(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		templates.ThemeSelectError().Render(r.Context(), w)
+		return
+	}
+
+	personID := strings.TrimSpace(r.FormValue("person_id"))
+	text := strings.TrimSpace(r.FormValue("text"))
+	if personID == "" || text == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		templates.ThemeSelectError().Render(r.Context(), w)
+		return
+	}
+
+	themeID := xid.New().String()
+	if _, err := h.queries.CreateTheme(r.Context(), db.CreateThemeParams{
+		ID:       themeID,
+		PersonID: personID,
+		Text:     text,
+	}); err != nil {
+		zap.L().Error("error creating theme", zap.Error(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		templates.ThemeSelectError().Render(r.Context(), w)
+		return
+	}
+
+	selected := map[string]bool{}
+	for _, t := range r.Form["themes"] {
+		selected[t] = true
+	}
+	selected[themeID] = true
+
+	rows, err := h.queries.ListThemesByPersonID(r.Context(), db.ListThemesByPersonIDParams{
+		PersonID: personID,
+		Offset:   0,
+		Limit:    100,
+	})
+	if err != nil {
+		zap.L().Error("error listing themes", zap.Error(err))
 		w.WriteHeader(http.StatusInternalServerError)
 		templates.ThemeSelectError().Render(r.Context(), w)
 		return

--- a/internal/handlers/form_adapter.go
+++ b/internal/handlers/form_adapter.go
@@ -116,12 +116,6 @@ func (f *FormAdapter) ParseCreateActionRequest(r *http.Request) (*api.CreateActi
 		}
 	}
 
-	// Parse new theme name
-	newTheme := strings.TrimSpace(r.FormValue("new_theme"))
-	if newTheme != "" {
-		req.NewTheme = api.NewOptString(newTheme)
-	}
-
 	return req, nil
 }
 

--- a/internal/middleware/form_adapter.go
+++ b/internal/middleware/form_adapter.go
@@ -58,14 +58,15 @@ func (f *FormToJSONAdapter) convertFormToJSON(r *http.Request) ([]byte, error) {
 	}
 
 	// Determine the type of form based on URL path
-	if strings.Contains(r.URL.Path, "/people") {
+	switch {
+	case strings.HasPrefix(r.URL.Path, "/people"):
 		return f.convertPersonForm(r)
-	} else if strings.Contains(r.URL.Path, "/actions") {
+	case strings.HasPrefix(r.URL.Path, "/actions"):
 		return f.convertActionForm(r)
+	default:
+		// Unknown form type - skip conversion
+		return nil, nil
 	}
-
-	// Unknown form type - skip conversion
-	return nil, nil
 }
 
 // convertPersonForm converts person form data to JSON

--- a/internal/middleware/form_adapter.go
+++ b/internal/middleware/form_adapter.go
@@ -141,6 +141,20 @@ func (f *FormToJSONAdapter) convertActionForm(r *http.Request) ([]byte, error) {
 		data["references"] = references
 	}
 
+	// Optional themes field
+	if themes := r.Form["themes"]; len(themes) > 0 {
+		clean := make([]string, 0, len(themes))
+		for _, t := range themes {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				clean = append(clean, t)
+			}
+		}
+		if len(clean) > 0 {
+			data["themes"] = clean
+		}
+	}
+
 	return json.Marshal(data)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,6 +129,7 @@ func setupRoutes(apiServer *api.Server, personHandler *handlers.PersonHandler, a
 	// Legacy form handlers for HTMX compatibility (keeping for now)
 	mux.HandleFunc("/forms/people/select", personHandler.HandleGetPersonsForSelect)
 	mux.HandleFunc("/forms/themes/select", actionHandler.HandleGetThemesForSelect)
+	mux.HandleFunc("/forms/themes/create", actionHandler.HandleCreateTheme)
 
 	// Consolidated API routes with content negotiation (supports both JSON and HTML)
 	mux.Handle("/api/v1/", http.StripPrefix("/api/v1", apiServer))

--- a/templates/action.templ
+++ b/templates/action.templ
@@ -186,15 +186,24 @@ templ RecordActionForm(personID string, targetSelector string) {
                                                 <option value="">Select a person first</option>
                                         }
                                 </select>
-                        </div>
-                        <div>
-                                <label class="block text-sm font-medium text-gray-700 mb-1">Add new theme</label>
-                                <input
-                                        type="text"
-                                        name="new_theme"
-                                        placeholder="e.g. communication"
-                                        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                />
+                                <div class="flex items-center gap-2 mt-2">
+                                        <input
+                                                type="text"
+                                                id="new-theme-input"
+                                                name="text"
+                                                placeholder="Add new theme"
+                                                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                        />
+                                        <button
+                                                type="button"
+                                                class="px-3 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                                hx-post="/forms/themes/create"
+                                                hx-include="#new-theme-input,[name=person_id],#theme-select"
+                                                hx-target="#theme-select"
+                                                hx-swap="innerHTML"
+                                                hx-on::after-request="if(event.detail.successful) document.getElementById('new-theme-input').value=''"
+                                        >Add</button>
+                                </div>
                         </div>
 			<button
 				type="submit"
@@ -290,15 +299,24 @@ templ EditActionForm(action Action) {
                                 >
                                         @ThemeSelectLoading()
                                 </select>
-                        </div>
-                        <div>
-                                <label class="block text-sm font-medium text-gray-700 mb-1">Add new theme</label>
-                                <input
-                                        type="text"
-                                        name="new_theme"
-                                        placeholder="e.g. communication"
-                                        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                />
+                                <div class="flex items-center gap-2 mt-2">
+                                        <input
+                                                type="text"
+                                                id="new-theme-input"
+                                                name="text"
+                                                placeholder="Add new theme"
+                                                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                        />
+                                        <button
+                                                type="button"
+                                                class="px-3 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                                hx-post="/forms/themes/create"
+                                                hx-include="#new-theme-input,[name=person_id],#theme-select"
+                                                hx-target="#theme-select"
+                                                hx-swap="innerHTML"
+                                                hx-on::after-request="if(event.detail.successful) document.getElementById('new-theme-input').value=''"
+                                        >Add</button>
+                                </div>
                         </div>
                         <div class="flex justify-end space-x-2">
                                 <a

--- a/templates/action_templ.go
+++ b/templates/action_templ.go
@@ -432,7 +432,7 @@ func RecordActionForm(personID string, targetSelector string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</select></div><div><label class=\"block text-sm font-medium text-gray-700 mb-1\">Add new theme</label> <input type=\"text\" name=\"new_theme\" placeholder=\"e.g. communication\" class=\"w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500\"></div><button type=\"submit\" class=\"w-full px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500\" hx-indicator=\"#submit-indicator\"><span id=\"submit-indicator\" class=\"htmx-indicator\"><svg class=\"inline w-4 h-4 mr-2 animate-spin\" viewBox=\"0 0 24 24\"><circle class=\"opacity-25\" cx=\"12\" cy=\"12\" r=\"10\" stroke=\"currentColor\" stroke-width=\"4\" fill=\"none\"></circle> <path class=\"opacity-75\" fill=\"currentColor\" d=\"M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z\"></path></svg> Saving...</span> <span class=\"htmx-no-indicator\">Record Action</span></button></form></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</select><div class=\"flex items-center gap-2 mt-2\"><input type=\"text\" id=\"new-theme-input\" name=\"text\" placeholder=\"Add new theme\" class=\"w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500\"> <button type=\"button\" class=\"px-3 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500\" hx-post=\"/forms/themes/create\" hx-include=\"#new-theme-input,[name=person_id],#theme-select\" hx-target=\"#theme-select\" hx-swap=\"innerHTML\" hx-on::after-request=\"if(event.detail.successful) document.getElementById('new-theme-input').value=''\">Add</button></div></div><button type=\"submit\" class=\"w-full px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500\" hx-indicator=\"#submit-indicator\"><span id=\"submit-indicator\" class=\"htmx-indicator\"><svg class=\"inline w-4 h-4 mr-2 animate-spin\" viewBox=\"0 0 24 24\"><circle class=\"opacity-25\" cx=\"12\" cy=\"12\" r=\"10\" stroke=\"currentColor\" stroke-width=\"4\" fill=\"none\"></circle> <path class=\"opacity-75\" fill=\"currentColor\" d=\"M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z\"></path></svg> Saving...</span> <span class=\"htmx-no-indicator\">Record Action</span></button></form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -468,7 +468,7 @@ func EditActionForm(action Action) templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/actions/" + action.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 220, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 229, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
@@ -481,7 +481,7 @@ func EditActionForm(action Action) templ.Component {
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(action.PersonID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 221, Col: 85}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 230, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
@@ -494,7 +494,7 @@ func EditActionForm(action Action) templ.Component {
 		var templ_7745c5c3_Var25 string
 		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(action.Description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 229, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 238, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
@@ -527,7 +527,7 @@ func EditActionForm(action Action) templ.Component {
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(action.OccurredAt.Format("2006-01-02T15:04"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 265, Col: 100}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 274, Col: 100}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -540,7 +540,7 @@ func EditActionForm(action Action) templ.Component {
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(action.References)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 276, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 285, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -553,7 +553,7 @@ func EditActionForm(action Action) templ.Component {
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs("/forms/themes/select?person_id=" + action.PersonID + "&action_id=" + action.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 286, Col: 128}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 295, Col: 128}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
@@ -567,14 +567,14 @@ func EditActionForm(action Action) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</select></div><div><label class=\"block text-sm font-medium text-gray-700 mb-1\">Add new theme</label> <input type=\"text\" name=\"new_theme\" placeholder=\"e.g. communication\" class=\"w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500\"></div><div class=\"flex justify-end space-x-2\"><a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</select><div class=\"flex items-center gap-2 mt-2\"><input type=\"text\" id=\"new-theme-input\" name=\"text\" placeholder=\"Add new theme\" class=\"w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500\"> <button type=\"button\" class=\"px-3 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500\" hx-post=\"/forms/themes/create\" hx-include=\"#new-theme-input,[name=person_id],#theme-select\" hx-target=\"#theme-select\" hx-swap=\"innerHTML\" hx-on::after-request=\"if(event.detail.successful) document.getElementById('new-theme-input').value=''\">Add</button></div></div><div class=\"flex justify-end space-x-2\"><a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var29 templ.SafeURL
 		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinURLErrs("/")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 305, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 323, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary
- remove inline theme creation from action API request
- allow adding themes via dedicated /forms/themes/create endpoint
- update action forms to use discrete theme creation
- skip form-to-JSON conversion for non-API form submissions so theme creation works

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a7e53afaac832c8152c3f587f9dc77