### PR TITLE
Handle API prefix in form adapter

### DIFF
--- a/internal/middleware/form_adapter.go
+++ b/internal/middleware/form_adapter.go
@@ -58,14 +58,19 @@ func (f *FormToJSONAdapter) convertFormToJSON(r *http.Request) ([]byte, error) {
 	}
 
 	// Determine the type of form based on URL path
+	path := r.URL.Path
+	if strings.HasPrefix(path, "/api/v1") {
+		path = strings.TrimPrefix(path, "/api/v1")
+	}
+
 	switch {
-	case strings.HasPrefix(r.URL.Path, "/people"):
+	case strings.HasPrefix(path, "/people"):
 		return f.convertPersonForm(r)
-	case strings.HasPrefix(r.URL.Path, "/actions"):
+	case strings.HasPrefix(path, "/actions"):
 		return f.convertActionForm(r)
-	case strings.Contains(r.URL.Path, "/conversations"):
+	case strings.Contains(path, "/conversations"):
 		return f.convertConversationForm(r)
-	case strings.HasPrefix(r.URL.Path, "/forms/themes"):
+	case strings.HasPrefix(path, "/forms/themes"):
 		return f.convertThemeForm(r)
 	default:
 		// Unknown form type - skip conversion

--- a/internal/middleware/form_adapter_test.go
+++ b/internal/middleware/form_adapter_test.go
@@ -1,0 +1,54 @@
+package middleware_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"pepo/internal/middleware"
+)
+
+func TestFormToJSONAdapterHandlesAPIPrefix(t *testing.T) {
+	form := url.Values{}
+	form.Set("person_id", "abc123")
+	form.Set("description", "test action")
+	form.Set("valence", "positive")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/actions", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	var captured *http.Request
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+	})
+
+	middleware.NewFormToJSONAdapter(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	if captured == nil {
+		t.Fatalf("handler was not called")
+	}
+
+	if ct := captured.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %s", ct)
+	}
+
+	var payload map[string]any
+	if err := json.NewDecoder(captured.Body).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	if payload["person_id"] != "abc123" {
+		t.Errorf("unexpected person_id: %v", payload["person_id"])
+	}
+	if payload["description"] != "test action" {
+		t.Errorf("unexpected description: %v", payload["description"])
+	}
+	if payload["valence"] != "positive" {
+		t.Errorf("unexpected valence: %v", payload["valence"])
+	}
+	if _, ok := payload["occurred_at"]; !ok {
+		t.Errorf("occurred_at missing from payload")
+	}
+}


### PR DESCRIPTION
## Summary
- handle `/api/v1` prefix when converting form submissions to JSON
- add test ensuring action forms posted to `/api/v1/actions` are converted

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68acbffaa588832cb8e41476ee5dd367