### PR TITLE
Implement create conversation endpoint

### DIFF
--- a/db/migrations/20250730230100_add_person_id_to_conversation.sql
+++ b/db/migrations/20250730230100_add_person_id_to_conversation.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+ALTER TABLE conversation
+    ADD COLUMN person_id BYTEA NOT NULL REFERENCES person(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_conversation_person_id ON conversation(person_id);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_conversation_person_id;
+ALTER TABLE conversation DROP COLUMN IF EXISTS person_id;

--- a/db/queries/conversations.sql
+++ b/db/queries/conversations.sql
@@ -1,7 +1,8 @@
 -- name: CreateConversation :one
-INSERT INTO conversation (id, description, occurred_at)
+INSERT INTO conversation (id, person_id, description, occurred_at)
 VALUES (
     x2b(sqlc.arg(id)),
+    x2b(sqlc.arg(person_id)),
     sqlc.arg(description),
     sqlc.arg(occurred_at)
 )

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -189,11 +189,11 @@ CREATE TABLE public.action_theme (
 
 CREATE TABLE public.conversation (
     id bytea NOT NULL,
-    person_id bytea NOT NULL,
     description text NOT NULL,
     occurred_at timestamp with time zone DEFAULT now() NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    person_id bytea NOT NULL,
     CONSTRAINT conversation_description_check CHECK ((length(TRIM(BOTH FROM description)) > 0))
 );
 
@@ -486,14 +486,6 @@ CREATE TRIGGER update_conversation_updated_at BEFORE UPDATE ON public.conversati
 
 
 --
--- Name: conversation conversation_person_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.conversation
-    ADD CONSTRAINT conversation_person_id_fkey FOREIGN KEY (person_id) REFERENCES public.person(id) ON DELETE CASCADE;
-
-
---
 -- Name: person update_person_updated_at; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -548,6 +540,14 @@ ALTER TABLE ONLY public.action_theme
 
 
 --
+-- Name: conversation conversation_person_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.conversation
+    ADD CONSTRAINT conversation_person_id_fkey FOREIGN KEY (person_id) REFERENCES public.person(id) ON DELETE CASCADE;
+
+
+--
 -- Name: conversation_theme conversation_theme_conversation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -585,4 +585,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20250730152732'),
     ('20250730204830'),
     ('20250730221000'),
-    ('20250730230000');
+    ('20250730230000'),
+    ('20250730230100');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -189,6 +189,7 @@ CREATE TABLE public.action_theme (
 
 CREATE TABLE public.conversation (
     id bytea NOT NULL,
+    person_id bytea NOT NULL,
     description text NOT NULL,
     occurred_at timestamp with time zone DEFAULT now() NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -394,6 +395,13 @@ CREATE INDEX idx_conversation_occurred_at ON public.conversation USING btree (oc
 
 
 --
+-- Name: idx_conversation_person_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_conversation_person_id ON public.conversation USING btree (person_id);
+
+
+--
 -- Name: idx_conversation_theme_conversation_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -475,6 +483,14 @@ CREATE TRIGGER update_conversation_theme_updated_at BEFORE UPDATE ON public.conv
 --
 
 CREATE TRIGGER update_conversation_updated_at BEFORE UPDATE ON public.conversation FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+
+--
+-- Name: conversation conversation_person_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.conversation
+    ADD CONSTRAINT conversation_person_id_fkey FOREIGN KEY (person_id) REFERENCES public.person(id) ON DELETE CASCADE;
 
 
 --

--- a/internal/db/conversations.sql.go
+++ b/internal/db/conversations.sql.go
@@ -11,17 +11,19 @@ import (
 )
 
 const createConversation = `-- name: CreateConversation :one
-INSERT INTO conversation (id, description, occurred_at)
+INSERT INTO conversation (id, person_id, description, occurred_at)
 VALUES (
     x2b($1),
-    $2,
-    $3
+    x2b($2),
+    $3,
+    $4
 )
-RETURNING conversation.id, conversation.description, conversation.occurred_at, conversation.created_at, conversation.updated_at
+RETURNING conversation.id, conversation.person_id, conversation.description, conversation.occurred_at, conversation.created_at, conversation.updated_at
 `
 
 type CreateConversationParams struct {
 	ID          string    `db:"id" json:"id"`
+	PersonID    string    `db:"person_id" json:"person_id"`
 	Description string    `db:"description" json:"description"`
 	OccurredAt  time.Time `db:"occurred_at" json:"occurred_at"`
 }
@@ -31,10 +33,16 @@ type CreateConversationRow struct {
 }
 
 func (q *Queries) CreateConversation(ctx context.Context, arg CreateConversationParams) (CreateConversationRow, error) {
-	row := q.db.QueryRowContext(ctx, createConversation, arg.ID, arg.Description, arg.OccurredAt)
+	row := q.db.QueryRowContext(ctx, createConversation,
+		arg.ID,
+		arg.PersonID,
+		arg.Description,
+		arg.OccurredAt,
+	)
 	var i CreateConversationRow
 	err := row.Scan(
 		&i.Conversation.ID,
+		&i.Conversation.PersonID,
 		&i.Conversation.Description,
 		&i.Conversation.OccurredAt,
 		&i.Conversation.CreatedAt,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -98,6 +98,7 @@ type ActionTheme struct {
 
 type Conversation struct {
 	ID          []byte    `db:"id" json:"id"`
+	PersonID    []byte    `db:"person_id" json:"person_id"`
 	Description string    `db:"description" json:"description"`
 	OccurredAt  time.Time `db:"occurred_at" json:"occurred_at"`
 	CreatedAt   time.Time `db:"created_at" json:"created_at"`

--- a/internal/handlers/conversation.go
+++ b/internal/handlers/conversation.go
@@ -20,6 +20,12 @@ func NewConversationHandler(queries *db.Queries) *ConversationHandler {
 
 // CreateConversation handles creating a conversation
 func (h *ConversationHandler) CreateConversation(ctx context.Context, req *api.CreateConversationRequest) (api.CreateConversationRes, error) {
+	if req.PersonID == "" {
+		return &api.CreateConversationBadRequest{
+			Message: "Person ID is required",
+			Code:    "VALIDATION_ERROR",
+		}, nil
+	}
 	if req.Description == "" {
 		return &api.CreateConversationBadRequest{
 			Message: "Description is required",
@@ -31,6 +37,7 @@ func (h *ConversationHandler) CreateConversation(ctx context.Context, req *api.C
 
 	row, err := h.queries.CreateConversation(ctx, db.CreateConversationParams{
 		ID:          id,
+		PersonID:    req.PersonID,
 		Description: req.Description,
 		OccurredAt:  req.OccurredAt,
 	})


### PR DESCRIPTION
## Summary
- add migration to link conversations to people
- store person ID when creating conversations
- validate required fields for conversation creation

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68acc09b5c0c832c9809a668a0f234f1