### PR TITLE
Avoid clearing action form when adding a theme

### DIFF
--- a/templates/action.templ
+++ b/templates/action.templ
@@ -86,7 +86,7 @@ templ ActionLoading() {
 templ RecordActionForm(personID string, targetSelector string) {
 	<div class="bg-white rounded-lg shadow p-6 mb-6">
 		<h2 class="text-xl font-semibold mb-4">Record New Action</h2>
-		<form hx-post="/api/v1/actions" hx-target={ targetSelector } hx-swap="afterbegin" hx-on::after-request="if(event.detail.successful) this.reset()" class="space-y-4">
+               <form hx-post="/api/v1/actions" hx-target={ targetSelector } hx-swap="afterbegin" hx-on::after-request="if(event.detail.elt === this && event.detail.successful) this.reset()" class="space-y-4">
 			if personID != "" {
 				<!-- Person is pre-selected -->
 				<input type="hidden" name="person_id" value={ personID }/>

--- a/templates/action_templ.go
+++ b/templates/action_templ.go
@@ -360,13 +360,13 @@ func RecordActionForm(personID string, targetSelector string) templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(targetSelector)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 89, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 89, Col: 73}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\" hx-swap=\"afterbegin\" hx-on::after-request=\"if(event.detail.successful) this.reset()\" class=\"space-y-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\" hx-swap=\"afterbegin\" hx-on::after-request=\"if(event.detail.elt === this && event.detail.successful) this.reset()\" class=\"space-y-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- prevent Record Action form from resetting when creating a theme

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b85c0726f8832c9c848fe070f5f342