### PR TITLE
Handle missing last activity fields in person listing

### DIFF
--- a/db/queries/persons.sql
+++ b/db/queries/persons.sql
@@ -20,10 +20,10 @@ SELECT
     p.name,
     p.created_at,
     p.updated_at,
-    la.description AS last_action_desc,
-    la.occurred_at AS last_action_at,
-    lc.description AS last_conversation_desc,
-    lc.occurred_at AS last_conversation_at
+    COALESCE(la.description, '') AS last_action_desc,
+    COALESCE(la.occurred_at, '0001-01-01T00:00:00Z'::timestamptz) AS last_action_at,
+    COALESCE(lc.description, '') AS last_conversation_desc,
+    COALESCE(lc.occurred_at, '0001-01-01T00:00:00Z'::timestamptz) AS last_conversation_at
 FROM person p
 LEFT JOIN LATERAL (
     SELECT description, occurred_at

--- a/internal/db/persons.sql.go
+++ b/internal/db/persons.sql.go
@@ -165,10 +165,10 @@ SELECT
     p.name,
     p.created_at,
     p.updated_at,
-    la.description AS last_action_desc,
-    la.occurred_at AS last_action_at,
-    lc.description AS last_conversation_desc,
-    lc.occurred_at AS last_conversation_at
+    COALESCE(la.description, '') AS last_action_desc,
+    COALESCE(la.occurred_at, '0001-01-01T00:00:00Z'::timestamptz) AS last_action_at,
+    COALESCE(lc.description, '') AS last_conversation_desc,
+    COALESCE(lc.occurred_at, '0001-01-01T00:00:00Z'::timestamptz) AS last_conversation_at
 FROM person p
 LEFT JOIN LATERAL (
     SELECT description, occurred_at


### PR DESCRIPTION
## Summary
- avoid SQL scan errors when last action or conversation is absent by coalescing nullable fields
- regenerate database query code

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b89e776b8c832c8807f05d0e13109b