### PR TITLE
feat: add pages for recording actions and conversations

### DIFF
--- a/templates/action.templ
+++ b/templates/action.templ
@@ -349,3 +349,10 @@ templ EditActionPage(action Action) {
                 @EditActionForm(action)
         }
 }
+
+templ RecordActionPage(personID string) {
+        @Layout("Record Action") {
+                @RecordActionForm(personID, "#action-form-result")
+                <div id="action-form-result" class="mt-4"></div>
+        }
+}

--- a/templates/action_templ.go
+++ b/templates/action_templ.go
@@ -635,4 +635,55 @@ func EditActionPage(action Action) templ.Component {
 	})
 }
 
+func RecordActionPage(personID string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var32 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var32 == nil {
+			templ_7745c5c3_Var32 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var33 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = RecordActionForm(personID, "#action-form-result").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, " <div id=\"action-form-result\" class=\"mt-4\"></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = Layout("Record Action").Render(templ.WithChildren(ctx, templ_7745c5c3_Var33), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 var _ = templruntime.GeneratedTemplate

--- a/templates/conversation.templ
+++ b/templates/conversation.templ
@@ -84,3 +84,10 @@ templ RecordConversationForm(personID string, targetSelector string) {
         </div>
 }
 
+templ RecordConversationPage(personID string) {
+        @Layout("Record Conversation") {
+                @RecordConversationForm(personID, "#conversation-form-result")
+                <div id="conversation-form-result" class="mt-4"></div>
+        }
+}
+

--- a/templates/conversation_templ.go
+++ b/templates/conversation_templ.go
@@ -195,4 +195,55 @@ func RecordConversationForm(personID string, targetSelector string) templ.Compon
 	})
 }
 
+func RecordConversationPage(personID string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = RecordConversationForm(personID, "#conversation-form-result").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " <div id=\"conversation-form-result\" class=\"mt-4\"></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = Layout("Record Conversation").Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 var _ = templruntime.GeneratedTemplate

--- a/templates/index.templ
+++ b/templates/index.templ
@@ -3,10 +3,10 @@ package templates
 templ Index() {
         @Layout("Peppo!") {
                 @LockWrapper() {
-                        @RecordActionForm("", "#actions-dump")
-                        @RecordConversationForm("", "#conversations-dump")
-                        <div id="actions-dump" class="hidden"></div>
-                        <div id="conversations-dump" class="hidden"></div>
+                        <div class="mb-4 flex space-x-4">
+                                <a href="/actions/new" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Add Action</a>
+                                <a href="/conversations/new" class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded">Add Conversation</a>
+                        </div>
                         <div id="people-table" hx-get="/api/v1/people" hx-trigger="load">
                                 <p class="text-gray-500">Loading...</p>
                         </div>

--- a/templates/index_templ.go
+++ b/templates/index_templ.go
@@ -53,19 +53,7 @@ func Index() templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = RecordActionForm("", "#actions-dump").Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, " ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = RecordConversationForm("", "#conversations-dump").Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, " <div id=\"actions-dump\" class=\"hidden\"></div><div id=\"conversations-dump\" class=\"hidden\"></div><div id=\"people-table\" hx-get=\"/api/v1/people\" hx-trigger=\"load\"><p class=\"text-gray-500\">Loading...</p></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"mb-4 flex space-x-4\"><a href=\"/actions/new\" class=\"bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded\">Add Action</a> <a href=\"/conversations/new\" class=\"bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded\">Add Conversation</a></div><div id=\"people-table\" hx-get=\"/api/v1/people\" hx-trigger=\"load\"><p class=\"text-gray-500\">Loading...</p></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/templates/person.templ
+++ b/templates/person.templ
@@ -196,10 +196,10 @@ templ PersonDetail(person Person, timeline []TimelineItem) {
                                         <h1 class="text-2xl font-bold text-gray-900 mb-2">{ person.Name }</h1>
                                 </div>
                         </div>
-                        <!-- Record Conversation Form -->
-                        @RecordConversationForm(person.ID, "#timeline-list")
-                        <!-- Record Action Form -->
-                        @RecordActionForm(person.ID, "#timeline-list")
+                        <div class="mb-6 flex space-x-4">
+                                <a href={ "/conversations/new?person_id=" + person.ID } class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded">Add Conversation</a>
+                                <a href={ "/actions/new?person_id=" + person.ID } class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Add Action</a>
+                        </div>
                         <!-- Timeline section -->
                         <div class="bg-white rounded-lg shadow p-6">
                                 <div class="flex justify-between items-center mb-4">

--- a/templates/person_templ.go
+++ b/templates/person_templ.go
@@ -767,32 +767,42 @@ func PersonDetail(person Person, timeline []TimelineItem) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</h1></div></div><!-- Record Conversation Form --> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</h1></div></div><div class=\"mb-6 flex space-x-4\"><a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = RecordConversationForm(person.ID, "#timeline-list").Render(ctx, templ_7745c5c3_Buffer)
+				var templ_7745c5c3_Var37 templ.SafeURL
+				templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinURLErrs("/conversations/new?person_id=" + person.ID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/person.templ`, Line: 200, Col: 85}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, " <!-- Record Action Form --> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\" class=\"bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded\">Add Conversation</a> <a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = RecordActionForm(person.ID, "#timeline-list").Render(ctx, templ_7745c5c3_Buffer)
+				var templ_7745c5c3_Var38 templ.SafeURL
+				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinURLErrs("/actions/new?person_id=" + person.ID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/person.templ`, Line: 201, Col: 79}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, " <!-- Timeline section --> <div class=\"bg-white rounded-lg shadow p-6\"><div class=\"flex justify-between items-center mb-4\"><h2 class=\"text-xl font-semibold text-gray-900\">Timeline (")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "\" class=\"bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded\">Add Action</a></div><!-- Timeline section --> <div class=\"bg-white rounded-lg shadow p-6\"><div class=\"flex justify-between items-center mb-4\"><h2 class=\"text-xl font-semibold text-gray-900\">Timeline (")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var37 string
-				templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(len(timeline))
+				var templ_7745c5c3_Var39 string
+				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(len(timeline))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/person.templ`, Line: 206, Col: 113}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}


### PR DESCRIPTION
## Summary
- move action and conversation forms into dedicated pages
- link person and index pages to new creation pages
- route /actions/new and /conversations/new to serve new pages

## Testing
- `make generate-templ`
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b89f9f06c0832c8470481c5fa821a8