### PR TITLE
Prevent premature redirect on action edit page

### DIFF
--- a/templates/action.templ
+++ b/templates/action.templ
@@ -226,7 +226,7 @@ templ RecordActionForm(personID string, targetSelector string) {
 templ EditActionForm(action Action) {
         <div class="bg-white rounded-lg shadow p-6 mb-6">
                 <h2 class="text-xl font-semibold mb-4">Edit Action</h2>
-                <form hx-put={ "/api/v1/actions/" + action.ID } hx-on::after-request="if(event.detail.successful) window.location.href='/'" class="space-y-4">
+               <form hx-put={ "/api/v1/actions/" + action.ID } hx-on::after-request="if(event.detail.elt === this && event.detail.successful) window.location.href='/'" class="space-y-4">
                         <input type="hidden" name="person_id" value={ action.PersonID }/>
                         <div>
                                 <label class="block text-sm font-medium text-gray-700 mb-1">Description</label>

--- a/templates/action_templ.go
+++ b/templates/action_templ.go
@@ -468,13 +468,13 @@ func EditActionForm(action Action) templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/actions/" + action.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 229, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 229, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" hx-on::after-request=\"if(event.detail.successful) window.location.href='/'\" class=\"space-y-4\"><input type=\"hidden\" name=\"person_id\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" hx-on::after-request=\"if(event.detail.elt === this && event.detail.successful) window.location.href='/'\" class=\"space-y-4\"><input type=\"hidden\" name=\"person_id\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- avoid redirecting to home when theme select loads on action edit form
- ensure edit form only navigates after successful submission

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8a6038fe0832c82de94dcf226d99c