### PR TITLE
Add back buttons to action and conversation forms

### DIFF
--- a/templates/action.templ
+++ b/templates/action.templ
@@ -351,8 +351,17 @@ templ EditActionPage(action Action) {
 }
 
 templ RecordActionPage(personID string) {
-        @Layout("Record Action") {
-                @RecordActionForm(personID, "#action-form-result")
-                <div id="action-form-result" class="mt-4"></div>
-        }
+       @Layout("Record Action") {
+               if personID != "" {
+                       <a href={ "/people/" + personID } class="text-blue-600 hover:text-blue-800 flex items-center mb-4">
+                               \u2190 Back to Person
+                       </a>
+               } else {
+                       <a href="/" class="text-blue-600 hover:text-blue-800 flex items-center mb-4">
+                               \u2190 Back to People List
+                       </a>
+               }
+               @RecordActionForm(personID, "#action-form-result")
+               <div id="action-form-result" class="mt-4"></div>
+       }
 }

--- a/templates/action_templ.go
+++ b/templates/action_templ.go
@@ -668,11 +668,39 @@ func RecordActionPage(personID string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
+			if personID != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<a href=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var34 templ.SafeURL
+				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinURLErrs("/people/" + personID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/action.templ`, Line: 356, Col: 54}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\" class=\"text-blue-600 hover:text-blue-800 flex items-center mb-4\">\\u2190 Back to Person</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<a href=\"/\" class=\"text-blue-600 hover:text-blue-800 flex items-center mb-4\">\\u2190 Back to People List</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 			templ_7745c5c3_Err = RecordActionForm(personID, "#action-form-result").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, " <div id=\"action-form-result\" class=\"mt-4\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, " <div id=\"action-form-result\" class=\"mt-4\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/templates/conversation.templ
+++ b/templates/conversation.templ
@@ -85,9 +85,18 @@ templ RecordConversationForm(personID string, targetSelector string) {
 }
 
 templ RecordConversationPage(personID string) {
-        @Layout("Record Conversation") {
-                @RecordConversationForm(personID, "#conversation-form-result")
-                <div id="conversation-form-result" class="mt-4"></div>
-        }
+       @Layout("Record Conversation") {
+               if personID != "" {
+                       <a href={ "/people/" + personID } class="text-blue-600 hover:text-blue-800 flex items-center mb-4">
+                               \u2190 Back to Person
+                       </a>
+               } else {
+                       <a href="/" class="text-blue-600 hover:text-blue-800 flex items-center mb-4">
+                               \u2190 Back to People List
+                       </a>
+               }
+               @RecordConversationForm(personID, "#conversation-form-result")
+               <div id="conversation-form-result" class="mt-4"></div>
+       }
 }
 

--- a/templates/conversation_templ.go
+++ b/templates/conversation_templ.go
@@ -228,11 +228,39 @@ func RecordConversationPage(personID string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
+			if personID != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<a href=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var11 templ.SafeURL
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs("/people/" + personID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/conversation.templ`, Line: 90, Col: 54}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" class=\"text-blue-600 hover:text-blue-800 flex items-center mb-4\">\\u2190 Back to Person</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<a href=\"/\" class=\"text-blue-600 hover:text-blue-800 flex items-center mb-4\">\\u2190 Back to People List</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 			templ_7745c5c3_Err = RecordConversationForm(personID, "#conversation-form-result").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " <div id=\"conversation-form-result\" class=\"mt-4\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " <div id=\"conversation-form-result\" class=\"mt-4\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
## Summary
- add back navigation links on add action and add conversation pages

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8a59d54c4832ca00cd6d67f9b0db4