### PR TITLE
Add terminal chat CLI for Pepo agent

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,3 +11,25 @@ The database schema is managed using https://github.com/amacneil/dbmate
 The core database model is a Person, who has a name. The primary key is an xid: https://github.com/rs/xid
 
 The front-end will be implemented using HTMX: https://htmx.org/ and Tailwind CSS: https://tailwindcss.com/
+
+## Talking to the Pepo Agent
+
+You can start an interactive terminal session with the Pepo agent by building the CLI located in `cmd/agent`:
+
+```
+go build -o pepo-agent ./cmd/agent
+```
+
+Before running the binary, export your OpenAI API key:
+
+```
+export OPENAI_API_KEY=sk-...
+```
+
+The agent can then be launched with:
+
+```
+./pepo-agent
+```
+
+By default the tool will talk to a Pepo API server running at `http://localhost:8080`. Override this and other options with flags (for example `-api-base-url`) or the environment variables `PEPO_API_BASE_URL`, `PEPO_AGENT_SYSTEM`, `PEPO_AGENT_MAX_ROUNDS`, and `PEPO_AGENT_TIMEOUT`.

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	openai "github.com/sashabaranov/go-openai"
+
+	"pepo/internal/agent"
+	"pepo/internal/agent/tools"
+)
+
+func main() {
+	var (
+		apiBaseURL   = flag.String("api-base-url", getEnv("PEPO_API_BASE_URL", "http://localhost:8080"), "Base URL for the Pepo API")
+		model        = flag.String("model", getEnv("OPENAI_MODEL", ""), "OpenAI model to use for chat completions")
+		systemPrompt = flag.String("system", getEnv("PEPO_AGENT_SYSTEM", "You are Pepo, an assistant that helps managers understand their team's performance."), "System prompt for the agent")
+		maxRounds    = flag.Int("max-rounds", getEnvInt("PEPO_AGENT_MAX_ROUNDS", 6), "Maximum number of tool/response rounds per user message (0 = unlimited)")
+		timeout      = flag.Duration("timeout", getEnvDuration("PEPO_AGENT_TIMEOUT", 2*time.Minute), "Timeout for each LLM request")
+	)
+	flag.Parse()
+
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "OPENAI_API_KEY environment variable is required")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	openaiClient := openai.NewClient(apiKey)
+	llmOpts := make([]agent.OpenAIOption, 0, 1)
+	if *model != "" {
+		llmOpts = append(llmOpts, agent.WithOpenAIModel(*model))
+	}
+	llm := agent.NewOpenAIClient(openaiClient, llmOpts...)
+
+	apiTool, err := tools.NewAPITool(*apiBaseURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create API tool: %v\n", err)
+		os.Exit(1)
+	}
+
+	toolRegistry := agent.NewToolRegistry(apiTool)
+	agentOpts := []agent.AgentOption{
+		agent.WithSystemMessage(*systemPrompt),
+	}
+	if *maxRounds >= 0 {
+		agentOpts = append(agentOpts, agent.WithMaxRounds(*maxRounds))
+	}
+
+	pepoAgent := agent.New(llm, toolRegistry, agentOpts...)
+
+	reader := bufio.NewScanner(os.Stdin)
+	reader.Buffer(make([]byte, 0, 1024), 1024*1024)
+
+	fmt.Println("Starting Pepo agent conversation. Type 'exit' or 'quit' to end.")
+
+	for {
+		fmt.Print("You: ")
+		if !reader.Scan() {
+			fmt.Println()
+			break
+		}
+		input := strings.TrimSpace(reader.Text())
+		if input == "" {
+			continue
+		}
+		lower := strings.ToLower(input)
+		if lower == "exit" || lower == "quit" {
+			fmt.Println("Goodbye!")
+			break
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, *timeout)
+		response, err := pepoAgent.HandleUserMessage(reqCtx, input)
+		cancel()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			continue
+		}
+
+		fmt.Printf("Agent: %s\n", strings.TrimSpace(response.Content))
+	}
+}
+
+func getEnv(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func getEnvInt(key string, fallback int) int {
+	if value := os.Getenv(key); value != "" {
+		var parsed int
+		if _, err := fmt.Sscanf(value, "%d", &parsed); err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func getEnvDuration(key string, fallback time.Duration) time.Duration {
+	if value := os.Getenv(key); value != "" {
+		if parsed, err := time.ParseDuration(value); err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}


### PR DESCRIPTION
## Summary
- add a new `cmd/agent` binary that initializes the Pepo agent with the OpenAI-backed LLM and API tool for interactive conversations
- document how to build and run the chat CLI along with configuration environment variables in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dda56330ec832c9679bd6c0c53d884